### PR TITLE
feat: 레시피 이름 조회 api & 레시피 상세 조회 api

### DIFF
--- a/src/main/java/Fridge_Chef/team/config/WebConfig.java
+++ b/src/main/java/Fridge_Chef/team/config/WebConfig.java
@@ -1,6 +1,8 @@
 package Fridge_Chef.team.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -15,5 +17,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .allowedHeaders("*");
         ; // 쿠키 인증 요청 허용;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/Fridge_Chef/team/recipe/domain/Recipe.java
+++ b/src/main/java/Fridge_Chef/team/recipe/domain/Recipe.java
@@ -3,27 +3,37 @@ package Fridge_Chef.team.recipe.domain;
 
 import Fridge_Chef.team.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@Builder
 @Entity
 @Getter
 @Table
+@AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
 public class Recipe  extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
+    @GeneratedValue(generator = "uuid2")
+    @UuidGenerator
+    @Column(name = "recipe_id", columnDefinition = "BINARY(16)")
+    private UUID id;
     private String name; // 레시피 이름
     private String category; // 레시피 카테고리 (한식, 양식 등)
+
+    @Column(name = "instructions", columnDefinition = "TEXT")   //임시로 길이 늘림
     private String instructions; // 요리 순서
     private String imageUrl; // 레시피 이미지 URL
-    private Integer servings; // 인분
-    private Integer cookingTime; // 조리 시간
-    private String difficulty; // 난이도
+//    private Integer servings; // 인분
+//    private Integer cookingTime; // 조리 시간
+//    private String difficulty; // 난이도
 
 }

--- a/src/main/java/Fridge_Chef/team/recipe/repository/RecipeRepository.java
+++ b/src/main/java/Fridge_Chef/team/recipe/repository/RecipeRepository.java
@@ -1,0 +1,11 @@
+package Fridge_Chef.team.recipe.repository;
+
+import Fridge_Chef.team.recipe.domain.Recipe;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RecipeRepository extends JpaRepository<Recipe, UUID> {
+    Optional<Recipe> findByName(String recipeName);
+}

--- a/src/main/java/Fridge_Chef/team/recipe/rest/RecipeController.java
+++ b/src/main/java/Fridge_Chef/team/recipe/rest/RecipeController.java
@@ -1,11 +1,17 @@
 package Fridge_Chef.team.recipe.rest;
 
+import Fridge_Chef.team.exception.ApiException;
+import Fridge_Chef.team.recipe.rest.request.RecipeRequest;
 import Fridge_Chef.team.recipe.rest.request.SampleRequest;
 import Fridge_Chef.team.recipe.rest.response.SampleResponse;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import Fridge_Chef.team.recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 @RestController
@@ -13,14 +19,54 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class RecipeController {
 
+    private final RecipeService recipeService;
+
     @GetMapping()
-    public String info(){
+    public String info() {
         return "web request success";
     }
 
     @PostMapping("/test")
-    public SampleResponse docs(@RequestBody SampleRequest dto){
-        return new SampleResponse(dto.getName(),dto.getValue());
+    public SampleResponse docs(@RequestBody SampleRequest dto) {
+        return new SampleResponse(dto.getName(), dto.getValue());
     }
 
+    //레시피 이름 조회 api
+    //재료 -> 레시피 이름들
+    @GetMapping("/recipes")
+    public ResponseEntity<?> recipesFromIngredients(@RequestParam("ingredients") List<String> ingredients) throws ApiException{
+
+        try {
+            RecipeRequest request = new RecipeRequest(ingredients);
+            List<String> recipeTitles = recipeService.getRecipeTitles(request);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("recipe_names", recipeTitles);
+
+            return ResponseEntity.ok().body(response);
+        } catch (ApiException e) {
+            throw e;
+        }
+    }
+
+    //레시피 이름 조회 api
+    //이름 -> 레시피 이름들
+//    @GetMapping("/recipes")
+//    public void recipesFromName(@RequestParam("recipe_name") String name) {
+//
+//    }
+
+    //특정 레시피 상세 조회 api
+    @GetMapping("/recipes/details")
+    public ResponseEntity<?> recipeInfo(@RequestParam("recipe_name") String recipeName) throws ApiException{
+
+        try {
+            Map<String, Object> response = recipeService.getRecipeDetails(recipeName);
+            return ResponseEntity.ok().body(response);
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw e;
+        }
+    }
 }

--- a/src/main/java/Fridge_Chef/team/recipe/rest/request/RecipeRequest.java
+++ b/src/main/java/Fridge_Chef/team/recipe/rest/request/RecipeRequest.java
@@ -1,0 +1,26 @@
+package Fridge_Chef.team.recipe.rest.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecipeRequest {
+
+    //레시피 요청 dto
+    //ingredients 필드가 아예 없거나, 아무 재료도 없다면? -> not valid
+    @NotNull
+    @Size(min = 1)
+    private List<String> ingredients;
+
+    @Override
+    public String toString() {
+        return String.join(",", ingredients);
+    }
+}

--- a/src/main/java/Fridge_Chef/team/recipe/service/RecipeService.java
+++ b/src/main/java/Fridge_Chef/team/recipe/service/RecipeService.java
@@ -1,0 +1,154 @@
+package Fridge_Chef.team.recipe.service;
+
+import Fridge_Chef.team.exception.ApiException;
+import Fridge_Chef.team.exception.ErrorCode;
+import Fridge_Chef.team.recipe.domain.Recipe;
+import Fridge_Chef.team.recipe.repository.RecipeRepository;
+import Fridge_Chef.team.recipe.rest.request.RecipeRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+@RequiredArgsConstructor
+@Service
+public class RecipeService {
+
+    private final RecipeRepository recipeRepository;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${recipeRequestUrl}")
+    private String baseUrl;
+
+    //재료 AND조건으로 recipe titles 검색 메서드
+    public List<String> getRecipeTitles(RecipeRequest request) throws ApiException {
+
+        //요청 url 생성
+        String url = baseUrl + "/RCP_PARTS_DTLS=" + request.toString();
+        //레시피 조회 요청
+        JsonNode json = requestRecipe(url);
+        //레시피 이름 추출
+        List<String> recipeNames = extractRecipeNames(json);
+
+        return recipeNames;
+    }
+
+    //recipe 정보 json으로 리턴
+    public Map<String, Object> getRecipeDetails(String recipeName) throws ApiException {
+
+        Optional<Recipe> optionalRecipe = recipeRepository.findByName(recipeName);
+        //recipe 정보가 db에 저장이 되어 있음
+        if (!optionalRecipe.isEmpty()) {
+            Recipe recipe = optionalRecipe.get();
+            return recipeToJson(recipe);
+        }
+
+        //요청 url 생성
+        String url = baseUrl + "/RCP_NM=" + recipeName;
+        System.out.println(url);
+        //레시피 조회 요청
+        JsonNode json = requestRecipe(url);
+        System.out.println(json);
+        //레시피 정보 추출
+        Recipe recipe = extractRecipeDetails(json);
+        recipeRepository.save(recipe);
+
+        return recipeToJson(recipe);
+    }
+
+    //레시피 조회 요청 메서드
+    private JsonNode requestRecipe(String url) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        //요청 body 필요 없음. 헤더만 적재
+        HttpEntity<String> request = new HttpEntity<>(null, headers);
+
+        //get 요청
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);
+            String responseBody = response.getBody();
+
+            return objectMapper.readTree(responseBody);
+        } catch (Exception e) {
+            //요쳥 실패 400 bad request?
+            throw new ApiException(ErrorCode.INVALID_VALUE);
+        }
+    }
+
+    //JSON에서 레시피 이름 추출 메서드
+    private List<String> extractRecipeNames(JsonNode json) {
+
+        List<String> recipeNames = new ArrayList<>();
+
+        JsonNode cookRcpNode = json.path("COOKRCP01");
+        JsonNode rowArray = cookRcpNode.path("row");
+
+        if (rowArray.isArray()) {
+            for (JsonNode node : rowArray) {
+                JsonNode recipeName = node.get("RCP_NM");
+                if (recipeName != null) {
+                    recipeNames.add(recipeName.asText());
+                }
+            }
+        }
+
+        return recipeNames;
+    }
+
+    //json에서 레시피 상세 정보 추출 -> Recipe 엔티티 반환
+    private Recipe extractRecipeDetails(JsonNode json) {
+
+        JsonNode recipeInfo = json.get("COOKRCP01").get("row").get(0);
+
+        //json 추출
+        String name = recipeInfo.get("RCP_NM").asText();
+        String category = recipeInfo.get("RCP_PAT2").asText();
+//        String ingredients = recipeInfo.get("RCP_PARTS_DTLS").asText();
+        String instructions = extractInstructions(recipeInfo);
+        String imageUrl = recipeInfo.get("ATT_FILE_NO_MAIN").asText();
+
+        //엔티티 반환
+        return Recipe.builder()
+                .name(name)
+                .category(category)
+                .instructions(instructions)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+    //요리 순서 추출
+    private String extractInstructions(JsonNode recipeInfo) {
+
+        StringBuilder instructions = new StringBuilder();
+
+        for (int i = 1; i <= 20; i++) {
+            String manual = recipeInfo.get("MANUAL" + String.format("%02d", i)).asText();
+            if (manual != null && !manual.isEmpty()) {
+                instructions.append(manual).append("\n");
+            }
+        }
+        return instructions.toString().trim();
+    }
+
+    //엔티티 -> json 변환
+    private Map<String, Object> recipeToJson(Recipe recipe) {
+
+        Map<String, Object> recipeDetails = new HashMap<>();
+        recipeDetails.put("name", recipe.getName());
+        recipeDetails.put("category", recipe.getCategory());
+        recipeDetails.put("instructions", recipe.getInstructions());
+        recipeDetails.put("imageUrl", recipe.getImageUrl());
+
+        return recipeDetails;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,11 +13,15 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2-console #h2 console 접속 위해 추가
 
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         order_inserts: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,6 @@ spring:
   output:
     ansi:
       enabled: always
+
+#recipe 조회 사용 url
+recipeRequestUrl: ${URL}


### PR DESCRIPTION
### 1. Recipe entity 수정
- 엔티티 생성시 빌더 패턴 적용
- 컬럼 아직 정해진 게 없음. 임의로 지움
- instructions 문자열 길어서 임의로 type 수정

### 2. RecipeService
레시피 관련 비즈니스 로직 수행, DB 저장, 레시피 정보 JSON 형태로 반환
- 재료로 레시피 이름 검색 : getRecipeTitles(RecipeRequest request)
- 레시피 상세 정보 조회 : getRecipeDetails(String recipeName)
- 레시피 정보 요청 : requestRecipe(String url)
- 레시피 이름 추출 : extractRecipeNames(JsonNode json)
- 레시피 상세 정보 추출 : extractRecipeDetails(JsonNode json)
- 레시피 요리 순서 추출 : extractInstructions(JsonNode recipeInfo)